### PR TITLE
[WF] Update workflow with new typesense and local scraping solution

### DIFF
--- a/.github/workflows/update-gcs-bucket.yaml
+++ b/.github/workflows/update-gcs-bucket.yaml
@@ -25,11 +25,14 @@ jobs:
           if [[ "${{ github.ref_name }}" == "main" ]]; then
               echo "bucket=docs.camino.network" >> $GITHUB_OUTPUT
               echo "collection=camino-docs-`date +%s`" >> $GITHUB_OUTPUT
-              echo "loadbalancer=docs-lb" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref_name }}" == "dev" ]]; then
               echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
               echo "collection=camino-docs-dev-`date +%s`" >> $GITHUB_OUTPUT
-              echo "loadbalancer=dev-docs-lb" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_name }}" == "update-workflow" ]]; then
+              echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
+              echo "collection=camino-docs-dev-`date +%s`" >> $GITHUB_OUTPUT
+          else
+              exit 1
           fi
 
       - uses: actions/setup-node@v3
@@ -45,6 +48,17 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Serve local site for the scraper
+        run: docker run -d -p80:80 -v$PWD/build:/usr/share/nginx/html nginx:stable-alpine
+
+      - name: Run local scraping and push to TypeSense
+        run: |
+          sed -i "s/https:\/\/docs.camino.network/http:\/\/host.docker.internal/" scraper/docsearch-config.json
+          sed -i "s/camino-docs-default/${{ steps.prepareVariables.outputs.collection }}/" scraper/docsearch-config.json
+          ENV_FILE=$(readlink -f scraper/env-file)
+          CONFIG=$(cat scraper/docsearch-config.json | jq -r tostring)
+          docker run -i --add-host=host.docker.internal:host-gateway -e"TYPESENSE_API_KEY=${{ secrets.TYPESENSE_ADMIN_KEY }}" --env-file=$ENV_FILE -e "CONFIG=$CONFIG" typesense/docsearch-scraper
+
       - name: Cloud authentication
         id: auth
         uses: 'google-github-actions/auth@v1'
@@ -57,14 +71,3 @@ jobs:
       - name: Update bucket
         run: |
           gsutil -m rsync -R -d build gs://${{ steps.prepareVariables.outputs.bucket }}
-
-      - name: Serve local site for the scraper
-        run: docker run -d -p80:80 -v$PWD/build:/usr/share/nginx/html nginx:stable-alpine
-
-      - name: Run local scraping and push to TypeSense
-        run: |
-          sed -i "s/https:\/\/docs.camino.network/http:\/\/host.docker.internal/" scraper/docsearch-config.json
-          sed -i "s/camino-docs-default/${{ steps.prepareVariables.outputs.collection }}/" scraper/docsearch-config.json
-          ENV_FILE=$(readlink -f scraper/env-file)
-          CONFIG=$(cat scraper/docsearch-config.json | jq -r tostring)
-          docker run -i --add-host=host.docker.internal:host-gateway -e"TYPESENSE_API_KEY=${{ secrets.TYPESENSE_ADMIN_KEY }}" --env-file=$ENV_FILE -e "CONFIG=$CONFIG" typesense/docsearch-scraper

--- a/.github/workflows/update-gcs-bucket.yaml
+++ b/.github/workflows/update-gcs-bucket.yaml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build_deploy_scrape:
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
     name: Build, Deploy & Scrape
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-gcs-bucket.yaml
+++ b/.github/workflows/update-gcs-bucket.yaml
@@ -9,39 +9,62 @@ on:
 
 env:
   node_version: 16
+  typesense_url: https://typesense.camino.network
+  default_collection_name: camino-docs-default
 
 jobs:
-  BuildAndDeploy:
+  build_deploy_scrape:
+    name: Build, Deploy & Scrape
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Prepare variables
+        id: prepareVariables
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+              echo "bucket=docs.camino.network" >> $GITHUB_OUTPUT
+              echo "collection=camino-docs-`date +%s`" >> $GITHUB_OUTPUT
+              echo "loadbalancer=docs-lb" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_name }}" == "dev" ]]; then
+              echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
+              echo "collection=camino-docs-dev-`date +%s`" >> $GITHUB_OUTPUT
+              echo "loadbalancer=dev-docs-lb" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           
-      - name: install yarn dependencies        
+      - name: Install yarn dependencies        
         run: yarn install
 
-      - name: build
+      - name: Set collection name for Docusaurus
+        run: sed -i "s/camino-docs-default/${{ steps.prepareVariables.outputs.collection }}/g" docusaurus.config.js
+
+      - name: Build
         run: yarn build
 
-      - name: set bucket names
-        id: setBucketNames
-        run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
-              echo "bucket=docs.camino.network" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref_name }}" == "dev" ]]; then
-              echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
-          fi
-
-      - name: 'gcloud authentication'
-        id: 'auth'
+      - name: Cloud authentication
+        id: auth
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
 
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
 
-      - name: update bucket files
-        run: gsutil rsync -R -d build gs://${{ steps.setBucketNames.outputs.bucket }}
+      - name: Update bucket
+        run: |
+          gsutil -m rsync -R -d build gs://${{ steps.prepareVariables.outputs.bucket }}
+
+      - name: Serve local site for the scraper
+        run: docker run -d -p80:80 -v$PWD/build:/usr/share/nginx/html nginx:stable-alpine
+
+      - name: Run local scraping and push to TypeSense
+        run: |
+          sed -i "s/https:\/\/docs.camino.network/http:\/\/host.docker.internal/" scraper/docsearch-config.json
+          sed -i "s/camino-docs-default/${{ steps.prepareVariables.outputs.collection }}/" scraper/docsearch-config.json
+          ENV_FILE=$(readlink -f scraper/env-file)
+          CONFIG=$(cat scraper/docsearch-config.json | jq -r tostring)
+          docker run -i --add-host=host.docker.internal:host-gateway -e"TYPESENSE_API_KEY=${{ secrets.TYPESENSE_ADMIN_KEY }}" --env-file=$ENV_FILE -e "CONFIG=$CONFIG" typesense/docsearch-scraper

--- a/.github/workflows/update-gcs-bucket.yaml
+++ b/.github/workflows/update-gcs-bucket.yaml
@@ -28,9 +28,6 @@ jobs:
           elif [[ "${{ github.ref_name }}" == "dev" ]]; then
               echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
               echo "collection=camino-docs-dev-`date +%s`" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref_name }}" == "update-workflow" ]]; then
-              echo "bucket=dev.docs.camino.network" >> $GITHUB_OUTPUT
-              echo "collection=camino-docs-dev-`date +%s`" >> $GITHUB_OUTPUT
           else
               exit 1
           fi

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -107,16 +107,16 @@ const config = {
         darkTheme: darkCodeTheme,
       },
       typesense: {
-        typesenseCollectionName: 'camino-docs',
+        typesenseCollectionName: 'camino-docs-default',
         typesenseServerConfig: {
           nodes: [
             {
-              host: 'docs.camino.foundation',
-              port: 8108,
+              host: 'typesense.camino.network',
+              port: 443,
               protocol: 'https',
             },
           ],
-          apiKey: 'K3s7dltmYhPw0oqOepeOx8liLZPRAGH2',
+          apiKey: 'TfCsn1wHrrpAzkHQP7747iPAS83Rsqn3',
         },
         typesenseSearchParameters: {
           replaceSynonymsInHighlight:false,

--- a/scraper/docsearch-config.json
+++ b/scraper/docsearch-config.json
@@ -1,11 +1,6 @@
 {
-  "index_name": "camino-docs",
-  "start_urls": [
-    {
-      "url": "https://docs.camino.foundation",
-      "tags": ["prod"]
-    }
-  ],
+  "index_name": "camino-docs-default",
+  "start_urls": ["https://docs.camino.network"],
   "stop_urls": [],
   "selectors": {
     "lvl0": "article h1",

--- a/scraper/env-file
+++ b/scraper/env-file
@@ -1,3 +1,3 @@
-TYPESENSE_HOST=docs.camino.foundation
-TYPESENSE_PORT=8108
+TYPESENSE_HOST=typesense.camino.network
+TYPESENSE_PORT=443
 TYPESENSE_PROTOCOL=https


### PR DESCRIPTION
This new updated workflow does the typesense scraping locally and pushes the indexes to new typesense server.

Some key points:
* Docusaurus config has default typesense collection name: `camino-docs-default`
* This name is aliased to one of the collections so running docs locally search still works
* New typesense server URL and port is updated in `scraper/env-file`
* Added `-m` option to `gsutil` for parallel/multithreaded copy, this compensated the time it takes for scraping. So the action still takes around ~3:30 mins.
* Script generates a unique name within the action and uses that for collection name in typesense. Sets this collection name in docusaurus config (`sed s/camino-docs-default/camino-docs-dev-xxxxxxx`).
* Dev and production sites have different collection names
* Every build is consistent with its own unique collection
* Scraper takes it's typesense api key from repo's secrets