### PR TITLE
Make dependabot use dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    target-branch: dev


### PR DESCRIPTION
Dependabot needs to use `dev` branch for PRs. Merging directly to `main` is not ideal.