### PR TITLE
Warn users for not using RC/Alpha Releases

### DIFF
--- a/docs/camino-node/set-up-node-manual-installation.md
+++ b/docs/camino-node/set-up-node-manual-installation.md
@@ -15,6 +15,12 @@ In this tutorial, we will:
 
 This tutorial is primarily geared toward developers and people interested in how the Camino Network works. If you're just interested in setting up a node for staking, you may want to follow the [Camino Node Install Script](set-up-node-with-installer.md) tutorial instead. The installer automates the installation process and sets it up as a system service, which is recommended for unattended operation. You may also try things out by following this tutorial first, and then later set up the node using the installer as a permanent solution.
 
+:::caution NODE VERSIONS
+
+Please make sure to use only the recommended node versions mentioned on the [Current Node Versions](/validator-guides/current-node-versions) page. Avoid using RC or Alpha releases on the mainnet.
+
+:::
+
 ## Requirements
 
 Camino is a lightweight protocol which let nodes run on commodity hardware. Note that as network usage increases, hardware requirements may change.

--- a/docs/camino-node/set-up-node-with-docker.md
+++ b/docs/camino-node/set-up-node-with-docker.md
@@ -23,6 +23,12 @@ The docker container assumes in the default configuration:
 - A mount-point will be used to mount the directory `/root/.caminogo` to a persistent storage
 - The port 9651 is accessible from the internet
 
+:::caution NODE VERSIONS
+
+Please make sure to use only the recommended node versions mentioned on the [Current Node Versions](/validator-guides/current-node-versions) page. Avoid using RC or Alpha releases on the mainnet.
+
+:::
+
 ## Configuration
 
 To change the configuration you have to pass another set of config-flags to the execution of Camino-Node. The list of config-flags can be found [here](./camino-node-config-flags).

--- a/docs/camino-node/set-up-node-with-installer.md
+++ b/docs/camino-node/set-up-node-with-installer.md
@@ -80,7 +80,7 @@ To download and run the script, enter the following in the terminal:
 ```bash
 wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/camino-node-installer.sh;\
 chmod 755 camino-node-installer.sh;\
-./camino-node-installer.sh ## if you run the node on testnet(columbus) please use ./camino-node-installer.sh --version v0.2.1-rc2
+./camino-node-installer.sh
 ```
 
 And we're off! The output should look something like this:

--- a/docs/camino-node/set-up-node-with-installer.md
+++ b/docs/camino-node/set-up-node-with-installer.md
@@ -22,6 +22,12 @@ This install script assumes:
 - Camino-Node is not running and not already installed as a service
 - User running the script has superuser privileges (can run `sudo`)
 
+:::caution NODE VERSIONS
+
+Please make sure to use only the recommended node versions mentioned on the [Current Node Versions](/validator-guides/current-node-versions) page. Avoid using RC or Alpha releases on the mainnet.
+
+:::
+
 ### Environment considerations
 
 If you run a different flavor of Linux, the script might not work as intended. It assumes `systemd` is used to run system services. Other Linux flavors might use something else, or might have files in different places than is assumed by the script.

--- a/docs/validator-guides/current-node-versions.md
+++ b/docs/validator-guides/current-node-versions.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 10
+title: Current Node Versions
+description: Which network runs which Node versions.
+---
+
+# Current Node Versions
+
+The following tables provide the recommended and minimum versions for Camino Network's mainnet and testnet.
+
+# Mainnet - Camino
+
+| Recommended Node Version | `v0.4.9` | https://github.com/chain4travel/camino-node/releases/latest     |
+| ------------------------ | -------- | --------------------------------------------------------------- |
+| Minimum Node Version     | `v0.4.9` | https://github.com/chain4travel/camino-node/releases/tag/v0.4.9 |
+
+# Testnet - Columbus
+
+| Recommended Node Version | `v0.4.9` | https://github.com/chain4travel/camino-node/releases/latest     |
+| ------------------------ | -------- | --------------------------------------------------------------- |
+| Minimum Node Version     | `v0.4.9` | https://github.com/chain4travel/camino-node/releases/tag/v0.4.9 |

--- a/scripts/camino-node-installer.sh
+++ b/scripts/camino-node-installer.sh
@@ -78,6 +78,9 @@ usage () {
   echo "Options:"
   echo "   --help            Shows this message"
   echo "   --list            Lists 10 newest versions available to install"
+#hide this option
+#  echo "   --list-all        Lists 10 newest versions available to install including RC and Alpha Releases"
+#  echo "                     Note: Please do not use RC/Alpha releases for mainnet"
   echo "   --version <tag>   Installs <tag> version"
   echo "   --reinstall       Run the installer from scratch, overwriting the old service file"
   echo ""
@@ -92,6 +95,15 @@ if [ $# -ne 0 ] #arguments check
 then
   case $1 in
     --list) #print version list and exit (last 10 versions)
+      echo "Available versions:"
+      wget -q -O - https://api.github.com/repos/chain4travel/camino-node/releases \
+      | grep tag_name \
+      | grep -v "rc\|alpha" \
+      | sed 's/.*: "\(.*\)".*/\1/' \
+      | head
+      exit 0
+      ;;
+    --list-all) #print version list including rc and alhpa releases and exit (last 10 versions)
       echo "Available versions:"
       wget -q -O - https://api.github.com/repos/chain4travel/camino-node/releases \
       | grep tag_name \


### PR DESCRIPTION
This PR:
* adds "Current Node Versions" page under validator guides
* updates pages about node installation, adding a warning to use the recommended node versions
* updates camino node installer script to exclude rc/alpha releases from the `--list` option
* adds a hidden option names `--list-all` to list all available node versions including rc/alpha

deployed at: https://playground.docs.camino.network/