### PR TITLE
[GUIDE] Automatically upgrade camino-node

### DIFF
--- a/docs/camino-node/auto-upgrade.md
+++ b/docs/camino-node/auto-upgrade.md
@@ -1,0 +1,182 @@
+---
+sidebar_position: 6
+title: Auto Upgrade Node
+description: Automatically Upgrade Camino Node
+---
+
+# Automatically Upgrade Camino Node
+
+This guide provides instructions on how to automatically upgrade camino-node using a bash script and crontab.
+
+## Automatic Install Script
+
+If you have previously installed camino-node using the autoinstall script, you can now configure an automatic
+upgrade with the following steps:
+
+### Download Node Upgrader
+
+First, download the node upgrader script. You can place this script anywhere on the node's operating system.
+For the sake of this guide, we will assume you put it under the `/root` directory.
+
+```
+wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/c4t/scripts/camino-node-upgrader.sh;\
+chmod 755 camino-node-upgrader.sh
+```
+
+**Usage:**
+
+The script accepts a single option `-u` followed by a username argument. Provide the username used to install camino-node.
+
+```
+# ./camino-node-upgrader.sh -h
+Usage: camino-node-upgrader.sh -u username
+```
+
+:::note DESINGED TO BE RUN AS ROOT
+
+This script is intended to be executed with root user privileges.
+
+:::
+
+### Edit Crontab File
+
+Edit the crontab file (`/etc/crontab`) and add the following line. Choose the desired time for the cron service to run the script.
+
+In the example below, the script will run every day at 08:00 and log its output to `/var/log/camino-node-upgrader.log`.
+You can check this file to review the script's actions.
+
+:::tip CUSTOMIZE UPGRADE TIME
+
+Customizing the upgrade time to suit your preferences is advisable instead of using the example provided. Doing so will prevent all nodes in the network from upgrading simultaneously, ensuring a smoother upgrade process overall.
+
+:::
+
+```cron
+0 8 * * *       root    /root/camino-node-upgrader.sh -u <username> >> /var/log/camino-node-upgrader.log 2>&1
+```
+
+:::tip CHANGE THE USERNAME
+
+Before saving, make sure to replace `<username>` in the crontab entry with the appropriate username.
+
+:::
+
+:::caution Important Precautions for Automatic Upgrades
+
+Keep in mind that performing automatic upgrades always involves certain risks. It is crucial to have a
+backup plan in place to address any unexpected issues that may arise during the upgrade process.
+Most importantly, ensure that you have backed up your node's staker keys.
+
+:::
+
+### Sample Output From Script
+
+Here is a sample output from a node that is updated from `v0.4.9` to `v1.0.0`.
+
+```
+*** Starting upgrade process for user: camino ***
+*** Date is: Thu Jul 27 22:36:01 UTC 2023 ***
+Found camino-node systemd service...
+Preparing environment...
+Found amd64 architecture...
+Checking latest release... latest camino-node version is: v1.0.0
+Getting current running node version... current running camino-node version is: v0.4.9
+Current Node version (v0.4.9) is NOT the latest (v1.0.0)
+Upgrading camino-node...
+Stopping service...done @Thu Jul 27 22:36:02 UTC 2023
+Node version found.
+Attempting to download: https://github.com/chain4travel/camino-node/releases/download/v1.0.0/camino-node-linux-amd64-v1.0.0.tar.gz
+
+     0K .......... .......... .......... .......... ..........  0% 1.51M 19s
+    50K .......... .......... .......... .......... ..........  0% 2.03M 17s
+   100K .......... .......... .......... .......... ..........  0% 4.15M 13s
+   150K .......... .......... .......... .......... ..........  0% 8.02M 11s
+--------------------8<--------------------
+ 29300K .......... .......... .......... .......... .......... 99% 11.1M 0s
+ 29350K .......... .......... .......... .......... .......... 99% 8.85M 0s
+ 29400K .......... .......... .......... .......... .......... 99% 8.59M 0s
+ 29450K .......... .......... .......... .......... .......... 99% 13.7M 0s
+ 29500K ..........                                            100% 18.5M=3.4s2023-07-27 22:36:07 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/492036145/6f1d02ce-373c-4369-b277-
+ada7df6ce5af?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230727%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230727T223602Z&X-Amz-Expires=300&X-Amz-Signature=0b206b166738adff6cde104
+079b7926e8e43b1e01abbd4c4f09882a8f006207d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=492036145&response-content-disposition=attachment%3B%20filename%3Dcamino-node-linux-amd64-v1.0.0.tar.gz&response-cont
+ent-type=application%2Foctet-stream [30218484/30218484] -> "camino-node-linux-amd64-v1.0.0.tar.gz" [1]
+Unpacking node files...
+camino-node-v1.0.0/tools/
+camino-node-v1.0.0/tools/cert
+camino-node-v1.0.0/LICENSE
+camino-node-v1.0.0/plugins/
+camino-node-v1.0.0/camino-node
+Node files unpacked into /home/camino/camino-node
+Node upgraded, starting service...done @Thu Jul 27 22:36:08 UTC 2023
+New node version:
+camino-node: v1.0.0, commit: c403cb6
+caminogo: v1.0.0-rc1, commit: 0c5035f69
+  compat: v1.0.0 [database: v1.4.5]
+Done!
+```
+
+If the latest released node version is the same as the one already installed, the output will look like this:
+
+```
+*** Starting upgrade process for user: camino ***
+*** Date is: Thu Jul 27 22:37:01 UTC 2023 ***
+Found camino-node systemd service...
+Preparing environment...
+Found amd64 architecture...
+Checking latest release... latest camino-node version is: v1.0.0
+Getting current running node version... current running camino-node version is: v1.0.0
+Current node version (v1.0.0) is the latest (v1.0.0). Skipping...
+```
+
+## Docker Compose
+
+If you have installed camino-node with Docker, you can enable auto-upgrades using Docker Compose with
+the following configuration:
+
+### Add Watchtower to Docker Compose
+
+Include the Watchtower service in your Docker Compose file to enable automatic upgrades for the camino-node container.
+
+```yaml
+version: "3.1"
+
+services:
+  camino:
+    image: c4tplatform/camino-node:latest
+    ports:
+      - 9650:9650
+      - 9651:9651
+    volumes:
+      - ./camino-data:/root/.caminogo
+    # Replace <public-ip> with your node's public IP address
+    command:
+      [
+        "./camino-node",
+        "--network-id=camino",
+        "--public-ip=<public-ip>",
+        "--http-host=0.0.0.0",
+      ]
+    restart: always
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: always
+    environment:
+      WATCHTOWER_POLL_INTERVAL: 86400
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_DEBUG: "true"
+      WATCHTOWER_LABEL_ENABLE: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+#### Customize Watchtower Poll Interval:
+
+Change the value of `WATCHTOWER_POLL_INTERVAL` (in seconds) above to your desired poll interval.
+In the provided example, it is set to 24 hours, default value of Watchtower.
+
+#### Set Your Public IP:
+
+Don't forget to specify your public IP address in the command line.

--- a/docs/camino-node/set-up-node-with-installer.md
+++ b/docs/camino-node/set-up-node-with-installer.md
@@ -78,7 +78,7 @@ So, now that you prepared your system and have the info ready, let's get to it.
 To download and run the script, enter the following in the terminal:
 
 ```bash
-wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/camino-node-installer.sh;\
+wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/c4t/scripts/camino-node-installer.sh;\
 chmod 755 camino-node-installer.sh;\
 ./camino-node-installer.sh
 ```

--- a/scripts/camino-node-upgrader.sh
+++ b/scripts/camino-node-upgrader.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# A script to check for latest version of camino-node and upgrade to that specific version.
+# Keep in mind that this script will downgrade if the latest tagged version lower then the installed one.
+#
+# This script is designed to be run as root from crontab
+#
+# Prerequisites for this script:
+#  - jq command installed
+# 
+# Usage:
+# camino-node-upgrader.sh -u <username> # where <username> is the user that installed camino-node
+#
+# Example crontab entry:
+# 0 23 * * *       root    /root/camino-node-upgrader.sh -u <username> >> /var/log/camino-node-upgrader.log 2>&1 
+
+
+unset -v CAMINO_NODE_USERNAME
+while getopts 'u:h' opt; do
+  case "$opt" in
+    u)
+      CAMINO_NODE_USERNAME="$OPTARG"
+      echo "*** Starting upgrade process for user: $CAMINO_NODE_USERNAME ***"
+      echo "*** Date is: `date` ***"
+      ;;
+   
+    ?|h)
+      echo "Usage: $(basename $0) -u username"
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+
+# Exit if no username is given
+if [ -z "$CAMINO_NODE_USERNAME" ]
+then 
+    echo "Please provide a username with -u option"
+    echo "Usage: $(basename $0) -u username"
+    exit
+fi
+
+if ! id "$CAMINO_NODE_USERNAME" >/dev/null 2>&1; then
+    echo "ERROR: User not found: $CAMINO_NODE_USERNAME"
+    echo "ERROR: Please provide the username that is used to install camino-node."
+    exit
+fi
+
+# Check if we are root or have sudo
+if ! ((EUID == 0)); then
+    echo "ERROR: The script is designed to run as root user. Please run it with sudo prefix."
+    exit
+fi
+
+# Check if camino-node is installed
+if test -f "/etc/systemd/system/camino-node.service"; then
+  echo "Found camino-node systemd service..."
+else
+  echo "ERROR: Can not find camino-node service installed. Please install camino-node to use this upgrade script."
+  exit 255
+fi
+
+# Check if we have jq
+if ! command -v jq &> /dev/null
+then
+    echo "jq command could not be found"
+    echo 'please install jq (on Ubuntu run "apt install jq"'
+    exit 1
+fi
+
+LATEST_RELEASE_URL="https://api.github.com/repos/chain4travel/camino-node/releases/latest"
+
+echo "Preparing environment..."
+foundArch="$(uname -m)"                         #get system architecture
+foundOS="$(uname)"                              #get OS
+if [ "$foundOS" != "Linux" ]; then
+  #sorry, don't know you.
+  echo "Unsupported operating system: $foundOS!"
+  echo "Exiting."
+  exit
+fi
+if [ "$foundArch" = "aarch64" ]; then
+  getArch="arm64"                               #we're running on arm arch (probably RasPi)
+  echo "Found arm64 architecture..."
+elif [ "$foundArch" = "x86_64" ]; then
+  getArch="amd64"                               #we're running on intel/amd
+  echo "Found amd64 architecture..."
+else
+  #sorry, don't know you.
+  echo "Unsupported architecture: $foundArch!"
+  echo "Exiting."
+  exit
+fi
+
+# Get latest released version with "latest" tag
+echo -n "Checking latest release..."
+export LATEST_VERSION=$(wget -q -O - $LATEST_RELEASE_URL \
+      | grep tag_name \
+      | grep -v "rc\|alpha" \
+      | sed 's/.*: "\(.*\)".*/\1/' \
+      | head -n 1)
+
+echo " latest camino-node version is: $LATEST_VERSION"
+
+# Get running camino-node's version
+echo -n "Getting current running node version..."
+
+# Check if have the current version
+if [ -z "$LATEST_VERSION" ]
+then 
+    echo "ERROR: Can not get the latest version. Exiting..."
+    exit 2
+fi
+
+export CURRENT_VERSION=$(curl -s -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"info.getNodeVersion"
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info | jq  -r ".result.gitVersion")
+
+echo " current running camino-node version is: $CURRENT_VERSION"
+
+# Check if have the current version
+if [ -z "$CURRENT_VERSION" ]
+then 
+    echo "ERROR: Can not get the current running version. Exiting..."
+    exit 3
+fi
+
+# Do the update if the version does not match the latest version
+# Keep in mind that this will downgrade the camino-node version if the latest 
+# version is lower then the installed one
+if [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]
+then
+    # Start the upgrade
+    echo "Current Node version ($CURRENT_VERSION) is NOT the latest ($LATEST_VERSION)"
+    echo "Upgrading camino-node..."
+    echo -n "Stopping service..."
+    systemctl stop camino-node
+    echo "done @`date`"
+
+    # Download and copy node files
+    mkdir -p /tmp/camino-node-install               #make a directory to work in
+    rm -rf /tmp/camino-node-install/*               #clean up in case previous install didn't
+    cd /tmp/camino-node-install
+
+    version=$LATEST_VERSION
+
+    fileName="https://github.com/chain4travel/camino-node/releases/download/$version/camino-node-linux-$getArch-$version.tar.gz"
+
+    if [[ `wget -S --spider $fileName  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
+        echo "Node version found."
+    else
+        echo "Unable to find camino-node version $version. Exiting."
+        echo -n "Restarting service..."
+        systemctl start camino-node
+        echo "done @`date`"
+      exit
+    fi
+
+    echo "Attempting to download: $fileName"
+    wget -nv --show-progress $fileName
+    echo "Unpacking node files..."
+    runuser -l $CAMINO_NODE_USERNAME -c 'mkdir -p $HOME/camino-node'
+    runuser -l $CAMINO_NODE_USERNAME -c 'tar xvf /tmp/camino-node-install/camino-node-linux*.tar.gz -C $HOME/camino-node --strip-components=1;'
+    rm camino-node-linux-*.tar.gz
+    runuser -l $CAMINO_NODE_USERNAME -c 'echo "Node files unpacked into $HOME/camino-node"'
+
+    echo -n "Node upgraded, starting service..."
+    systemctl start camino-node
+    echo "done @`date`"
+    echo "New node version:"
+    runuser -l $CAMINO_NODE_USERNAME -c '$HOME/camino-node/camino-node --version'
+    echo "Done!"
+    exit
+else
+    echo "Current node version ($CURRENT_VERSION) is the latest ($LATEST_VERSION). Skipping..."
+fi


### PR DESCRIPTION
This PR:
* Adds a script for camino-node upgrade, intended to be used from crontab by root user.
* Adds a page under Camino Node about automatically upgrading the node using the script and cron.
* Fixes URL for auto install script under automatic install guide.

Also Docker method will be added, updating this PR.

Deployed at: https://playground.docs.camino.network/camino-node/auto-upgrade