### PR TITLE
Update copyright to Camino Network Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (C) 2022, Chain4Travel AG. All rights reserved.
+Copyright (C) 2024, Camino Network Foundation. All rights reserved.
 
 Parts of the documentation are derived work, based on ava-labs 
 docs whose original notices appear below.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
             
           }
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Chain4Travel AG.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Camino Network Foundation`,
       },
       prism: {
         theme: lightCodeTheme,

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -28,7 +28,7 @@
     "description": "The label of footer link with label=GitHub linking to https://github.com/chain4travel/camino-docs"
   },
   "copyright": {
-    "message": "Copyright © 2022 Chain4Travel AG",
+    "message": "Copyright © 2024 Camino Network Foundation",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
This PR updates copyright from Chain4Travel to Camino Network Foundation.