### PR TITLE
Prevent api urls to become links

### DIFF
--- a/docs/about/columbus-testnet.md
+++ b/docs/about/columbus-testnet.md
@@ -13,7 +13,7 @@ The Columbus testnet is undergoing constant improvement and despite the fact tha
 
 ## On-Chain Development
 
-For on-chain development like deploying and testing solidity-based smart-contracts all you need is a RPC/HTTP endpoint to the Columbus network. Our main HTTP/RPC node is reachable via the URL https://columbus.camino.network. By default you don't need to specify a port as the HTTPS port `443`, as well as the default port of the node `9650` are both routed to our HTTP-Enabled Columbus testnet node.
+For on-chain development like deploying and testing solidity-based smart-contracts all you need is a RPC/HTTP endpoint to the Columbus network. Our main HTTP/RPC node is reachable via the URL **`https://columbus.camino.network`**. By default you don't need to specify a port as the HTTPS port `443`, as well as the default port of the node `9650` are both routed to our HTTP-Enabled Columbus testnet node.
 
 ## Metamask configuration
 

--- a/docs/guides/metamask-rpc-endpoints.md
+++ b/docs/guides/metamask-rpc-endpoints.md
@@ -23,19 +23,19 @@ Camino Network is on ChainList.org. You can automatically add Camino networks to
 
 |    Network Name: |               Camino (mainnet)                |
 | ---------------: | :-------------------------------------------: |
-|         RPC URL: |    https://api.camino.network/ext/bc/C/rpc    |
+|         RPC URL: |   `https://api.camino.network/ext/bc/C/rpc`   |
 |        Chain-ID: |                     `500`                     |
 | Currency Symbol: |                     `CAM`                     |
 |  Block Explorer: | https://suite.camino.network/explorer/c-chain |
 
 #### Columbus Testnet
 
-|    Network Name: |              Columbus (testnet)               |
-| ---------------: | :-------------------------------------------: |
-|         RPC URL: | https://columbus.camino.network/ext/bc/C/rpc  |
-|        Chain-ID: |                     `501`                     |
-| Currency Symbol: |                     `CAM`                     |
-|  Block Explorer: | https://suite.camino.network/explorer/c-chain |
+|    Network Name: |               Columbus (testnet)               |
+| ---------------: | :--------------------------------------------: |
+|         RPC URL: | `https://columbus.camino.network/ext/bc/C/rpc` |
+|        Chain-ID: |                     `501`                      |
+| Currency Symbol: |                     `CAM`                      |
+|  Block Explorer: | https://suite.camino.network/explorer/c-chain  |
 
 ### Add Network to MetaMask
 


### PR DESCRIPTION
This PR prevents API URLs becoming links so the SEO tools do not complain that they are returning 404 errors.