### PR TITLE
added v1.1.0 version

### DIFF
--- a/.github/workflows/update-gcs-bucket.yaml
+++ b/.github/workflows/update-gcs-bucket.yaml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          
-      - name: Install yarn dependencies        
+
+      - name: Install yarn dependencies
         run: yarn install
 
       - name: Set collection name for Docusaurus
@@ -55,13 +55,14 @@ jobs:
 
       - name: Cloud authentication
         id: auth
-        uses: 'google-github-actions/auth@v1'
+        uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
       - name: Update bucket
         run: |
-          gsutil -m rsync -R -d build gs://${{ steps.prepareVariables.outputs.bucket }}
+          gcloud storage rm gs://${{ steps.prepareVariables.outputs.bucket }}/**
+          gcloud storage cp -z html,js,css,cast,svg,tf,woff,woff2 --recursive build/* gs://${{ steps.prepareVariables.outputs.bucket }}

--- a/docs/camino-node/set-up-node-with-installer.md
+++ b/docs/camino-node/set-up-node-with-installer.md
@@ -6,7 +6,7 @@ description: Use installation script for a quick and easy deployment
 
 # Camino Node Install Script
 
-We have a [shell (bash) script](https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/camino-node-installer.sh) that installs Camino-Node on your computer. This script sets up full, running node in a matter of minutes with minimal user input required.
+We have a [shell (bash) script](https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/caminogo-installer.sh) that installs Camino node on your computer. This script sets up full, running node in a matter of minutes with minimal user input required.
 
 ## Before you start
 

--- a/docs/camino-node/set-up-node-with-installer.md
+++ b/docs/camino-node/set-up-node-with-installer.md
@@ -78,9 +78,9 @@ So, now that you prepared your system and have the info ready, let's get to it.
 To download and run the script, enter the following in the terminal:
 
 ```bash
-wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/c4t/scripts/camino-node-installer.sh;\
-chmod 755 camino-node-installer.sh;\
-./camino-node-installer.sh
+wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/c4t/scripts/caminogo-installer.sh;\
+chmod 755 caminogo-installer.sh;\
+./caminogo-installer.sh
 ```
 
 And we're off! The output should look something like this:
@@ -235,7 +235,7 @@ It is recommended to always upgrade to the latest version, because new versions 
 To upgrade your node, just run the installer script again:
 
 ```bash
-./camino-node-installer.sh
+./caminogo-installer.sh
 ```
 
 It will detect that you already have Camino-Node installed:
@@ -278,7 +278,7 @@ The installer script can also be used to install a version of Camino-Node other 
 To see a list of available versions for installation, run:
 
 ```bash
-./camino-node-installer.sh --list
+./caminogo-installer.sh --list
 ```
 
 It will print out a list, something like:
@@ -294,7 +294,7 @@ v0.0.0
 To install a specific version, run the script with `--version` followed by the tag of the version. For example:
 
 ```bash
-./camino-node-installer.sh --version v0.1.0
+./caminogo-installer.sh --version v0.1.0
 ```
 
 :::danger
@@ -306,13 +306,13 @@ Note that not all Camino-Node versions are compatible. You should generally run 
 Installer script gets updated from time to time, with new features and capabilities added. To take advantage of new features or to recover from modifications that made the node fail, you may want to reinstall the node. To do that, fetch the latest version of the script from the web with:
 
 ```bash
-wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/camino-node-installer.sh
+wget -nd -m https://raw.githubusercontent.com/chain4travel/camino-docs/main/scripts/caminogo-installer.sh
 ```
 
 After the script has updated, run it again with the `--reinstall` config flag:
 
 ```bash
-./camino-node-installer.sh --reinstall
+./caminogo-installer.sh --reinstall
 ```
 
 This will delete the existing service file, and run the installer from scratch, like it was started for the first time. Note that the database and NodeID will be left intact.

--- a/docs/developer/guides/how-to-deploy-a-smart-contract.md
+++ b/docs/developer/guides/how-to-deploy-a-smart-contract.md
@@ -78,7 +78,14 @@ To request funds from the Discord faucet, follow these steps:
 1. Copy and paste your X-Address from the Camino Wallet.
 1. Enter the amount of CAM you wish to request, separating the command, X-Address and the requested amount with spaces.
 
-Please note that there is a limit of 50 CAM that can be requested within a 24-hour period.
+Please note that there is a limit of 150 CAM that can be requested within a 24-hour period.
+
+:::info FAUCET LIMIT
+
+The daily faucet limit is subject to change. Always check the faucet for the current
+limit. If your request exceeds the limit, the faucet will notify you.
+
+:::
 
 <figure>
 <img class="zoom" src="/img/deploy-smart-contract/1-deploy-sc-faucet.png"/>

--- a/docs/developer/guides/how-to-deploy-a-smart-contract.md
+++ b/docs/developer/guides/how-to-deploy-a-smart-contract.md
@@ -78,7 +78,7 @@ To request funds from the Discord faucet, follow these steps:
 1. Copy and paste your X-Address from the Camino Wallet.
 1. Enter the amount of CAM you wish to request, separating the command, X-Address and the requested amount with spaces.
 
-Please note that there is a limit of 150 CAM that can be requested within a 24-hour period.
+Please note that there is a limit of 150 CAM that can be requested within a 1-week period.
 
 :::info FAUCET LIMIT
 

--- a/docs/release-notes/camino-node.md
+++ b/docs/release-notes/camino-node.md
@@ -8,42 +8,48 @@ sidebar_position: 1
 
 `camino-node` is under very rapid development, this page may be outdated.
 
-For more up-to-date information please check [Github Release](https://github.com/chain4travel/camino-node/releases) page.
+For more up-to-date information please check [Github Release](https://github.com/chain4travel/caminogo/releases) page.
+
+[camino-node repository] (https://github.com/chain4travel/camino-node) is obsolete. All development now is done on [caminogo repository] (https://github.com/chain4travel/caminogo).
 
 :::
 
-## v1.0.0-rc1
+## v1.1.0
 
-<p><span class="alert alert--secondary pill">Pre-Release</span></p>
+<p><span class="alert alert--info pill">Berlin Phase</span></p>
+<p><span class="alert alert--warning pill">Current Mainnet (Camino) Version</span></p>
 <p><span class="alert alert--warning pill">Current Testnet (Columbus) Version</span></p>
 
-[View on GitHub](https://github.com/chain4travel/camino-node/releases/tag/v1.0.1-rc1)
+[View on GitHub](https://github.com/chain4travel/caminogo/releases/tag/v1.1.0)
+
+- Implementation of Berlin phase
+- Berlin Timestamp for Camino is 18.12.2024 at 10:00 UTC
+- Berlin Timestamp for Columbus is 28.11.2024 at 10:00 UTC
+- New DAC voting system
+- Enhanced address states with more granular roles
+- KYB verified address state introduction
+- Multisig alias improvements
+
+
+
+## v1.0.1
+
+[View on GitHub](https://github.com/chain4travel/camino-node/releases/tag/v1.0.1)
 
 - [Dependencies, Version] caminoethvm -> caminogo (Athens 1.0.1) by @evlekht
 - [[PVM] Returns pre-Athens rewardsImportTx logic for pre-Athens txs] by @evlekht
 - [[PVM, Spend] Allow spend to deposit unlocked tokens for different owner] by @evlekht
 - [[Dependency, fix] Fix state sync version (fork leftover)] by @evlekht
 
+**Full Changelog**: https://github.com/chain4travel/camino-node/compare/v1.0.0...v1.0.1
+
 ## v1.0.0
 
 <p><span class="alert alert--info pill">Athens Phase</span></p>
-<p><span class="alert alert--success pill">Current Mainnet (Camino) Version</span></p>
 
 [View on GitHub](https://github.com/chain4travel/camino-node/releases/tag/v1.0.0)
 
 - Official Athens Phase Release
-- ** Release notes same as `v1.0.0-rc1`**
-
-**Full Changelog**: https://github.com/chain4travel/camino-node/compare/v0.4.9...v1.0.0
-
-## v1.0.0-rc1
-
-<p><span class="alert alert--info pill">Athens Phase (Pre-Release)</span></p>
-<p><span class="alert alert--secondary pill">Pre-Release</span></p>
-
-[View on GitHub](https://github.com/chain4travel/camino-node/releases/tag/v1.0.0-rc1)
-
-- Athens version by @evlekht in #68
 
 **caminogo**
 
@@ -65,7 +71,7 @@ For more up-to-date information please check [Github Release](https://github.com
 - Admin API DNS Rebinding mitigation by @DerTiedemann in #62
 - Fix Validator reconnection when public IP changes
 
-**Full Changelog**: https://github.com/chain4travel/camino-node/compare/v0.4.9...v1.0.0-rc1
+**Full Changelog**: https://github.com/chain4travel/camino-node/compare/v0.4.9...v1.0.0
 
 ## v0.4.9
 

--- a/docs/release-notes/camino-node.md
+++ b/docs/release-notes/camino-node.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 
 For more up-to-date information please check [Github Release](https://github.com/chain4travel/caminogo/releases) page.
 
-[camino-node repository] (https://github.com/chain4travel/camino-node) is obsolete. All development now is done on [caminogo repository] (https://github.com/chain4travel/caminogo).
+[camino-node repository](https://github.com/chain4travel/camino-node) is obsolete. All development now is done on [caminogo repository](https://github.com/chain4travel/caminogo).
 
 :::
 

--- a/docs/release-notes/camino-node.md
+++ b/docs/release-notes/camino-node.md
@@ -30,8 +30,6 @@ For more up-to-date information please check [Github Release](https://github.com
 - KYB verified address state introduction
 - Multisig alias improvements
 
-
-
 ## v1.0.1
 
 [View on GitHub](https://github.com/chain4travel/camino-node/releases/tag/v1.0.1)

--- a/docs/release-notes/camino-node.md
+++ b/docs/release-notes/camino-node.md
@@ -1,34 +1,20 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Camino-Node Releases
 
-:::note UP-TO-DATE INFORMATION
+:::warning OBSOLETE
 
-`camino-node` is under very rapid development, this page may be outdated.
+The [camino-node repository](https://github.com/chain4travel/camino-node) is
+obsolete.
 
-For more up-to-date information please check [Github Release](https://github.com/chain4travel/caminogo/releases) page.
-
-[camino-node repository](https://github.com/chain4travel/camino-node) is obsolete. All development now is done on [caminogo repository](https://github.com/chain4travel/caminogo).
+Development has been transitioned from the
+[`camino-node`](https://github.com/chain4travel/camino-node) repository to the
+[`caminogo`](https://github.com/chain4travel/caminogo) repository as of the `v1.1.0`
+release. For release notes, please refer to the [this page](./caminogo.md).
 
 :::
-
-## v1.1.0
-
-<p><span class="alert alert--info pill">Berlin Phase</span></p>
-<p><span class="alert alert--warning pill">Current Mainnet (Camino) Version</span></p>
-<p><span class="alert alert--warning pill">Current Testnet (Columbus) Version</span></p>
-
-[View on GitHub](https://github.com/chain4travel/caminogo/releases/tag/v1.1.0)
-
-- Implementation of Berlin phase
-- Berlin Timestamp for Camino is 18.12.2024 at 10:00 UTC
-- Berlin Timestamp for Columbus is 28.11.2024 at 10:00 UTC
-- New DAC voting system
-- Enhanced address states with more granular roles
-- KYB verified address state introduction
-- Multisig alias improvements
 
 ## v1.0.1
 

--- a/docs/release-notes/caminogo.md
+++ b/docs/release-notes/caminogo.md
@@ -1,10 +1,29 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
-# CaminoGo (SDK) Releases
+# CaminoGo Releases
 
-## v0.2.0 ([View on GitHub](https://github.com/chain4travel/caminogo/releases/tag/v0.2.0)) {#v0_2_0}
+:::info
 
-- Based on avalancheGo v1.7.10
-- Sunrise Phase 0 (2022-05-16 T08:00 UTC)
+Development has been transitioned from the `camino-node` repository to the
+`caminogo` repository as of the `v1.1.0` release. For older versions, refer to the
+[`camino-node` page](./camino-node.md).
+
+:::
+
+## v1.1.0
+
+<p><span class="alert alert--info pill">Berlin Phase</span></p>
+<p><span class="alert alert--secondary pill">Current Mainnet (Camino) Version</span></p>
+<p><span class="alert alert--secondary pill">Current Testnet (Columbus) Version</span></p>
+
+[View on GitHub](https://github.com/chain4travel/caminogo/releases/tag/v1.1.0)
+
+- Implementation of Berlin phase
+- Berlin Timestamp for Camino is 18.12.2024 at 10:00 UTC
+- Berlin Timestamp for Columbus is 28.11.2024 at 10:00 UTC
+- New DAC voting system
+- Enhanced address states with more granular roles
+- KYB verified address state introduction
+- Multisig alias improvements

--- a/docs/validator-guides/current-node-versions.md
+++ b/docs/validator-guides/current-node-versions.md
@@ -11,11 +11,11 @@ The following tables provide the recommended and minimum versions for Camino Net
 # Mainnet - Camino
 
 | Recommended Node Version | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/latest     |
-| ------------------------ | -------- | --------------------------------------------------------------- |
+| ------------------------ | -------- | ------------------------------------------------------------ |
 | Minimum Node Version     | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0 |
 
 # Testnet - Columbus
 
-| Recommended Node Version | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0 |
+| Recommended Node Version | `v1.1.0`     | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0     |
 | ------------------------ | ------------ | ---------------------------------------------------------------- |
 | Minimum Node Version     | `v1.1.0-rc6` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0-rc6 |

--- a/docs/validator-guides/current-node-versions.md
+++ b/docs/validator-guides/current-node-versions.md
@@ -10,12 +10,12 @@ The following tables provide the recommended and minimum versions for Camino Net
 
 # Mainnet - Camino
 
-| Recommended Node Version | `v1.0.1` | https://github.com/chain4travel/camino-node/releases/latest     |
+| Recommended Node Version | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/latest     |
 | ------------------------ | -------- | --------------------------------------------------------------- |
-| Minimum Node Version     | `v1.0.0` | https://github.com/chain4travel/camino-node/releases/tag/v1.0.0 |
+| Minimum Node Version     | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0 |
 
 # Testnet - Columbus
 
-| Recommended Node Version | `v1.1.0-rc6` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0-rc6 |
+| Recommended Node Version | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0 |
 | ------------------------ | ------------ | ---------------------------------------------------------------- |
 | Minimum Node Version     | `v1.1.0-rc6` | https://github.com/chain4travel/caminogo/releases/tag/v1.1.0-rc6 |

--- a/docs/validator-guides/current-node-versions.md
+++ b/docs/validator-guides/current-node-versions.md
@@ -8,6 +8,15 @@ description: Node Versions Supported by Each Network
 
 The following tables provide the recommended and minimum versions for Camino Network's mainnet and testnet.
 
+:::tip NEW MAIN REPOSITORY
+
+Development has been transitioned from the
+[`camino-node`](https://github.com/chain4travel/camino-node) repository to the
+[`caminogo`](https://github.com/chain4travel/caminogo) repository as of the `v1.1.0`
+release.
+
+:::
+
 # Mainnet - Camino
 
 | Recommended Node Version | `v1.1.0` | https://github.com/chain4travel/caminogo/releases/latest     |

--- a/scripts/caminogo-installer.sh
+++ b/scripts/caminogo-installer.sh
@@ -5,14 +5,6 @@
 #stop on errors
 set -e
 
-## OBSOLETE
-## Use instead: https://github.com/chain4travel/camino-docs/blob/c4t/scripts/caminogo-installer.sh
-echo "This script is now obsolete. All development for the Camino node has been transitioned to the caminogo repository.  "
-echo
-echo "To install caminogo, use the new script available at:"
-echo "https://github.com/chain4travel/camino-docs/blob/c4t/scripts/caminogo-installer.sh"
-exit 1
-
 #running as root gives the wrong homedir, check and exit if run with sudo.
 if ((EUID == 0)); then
     echo "The script is not designed to run as root user. Please run it without sudo prefix."
@@ -104,7 +96,7 @@ then
   case $1 in
     --list) #print version list and exit (last 10 versions)
       echo "Available versions:"
-      wget -q -O - https://api.github.com/repos/chain4travel/camino-node/releases \
+      wget -q -O - https://api.github.com/repos/chain4travel/caminogo/releases \
       | grep tag_name \
       | grep -v "rc\|alpha" \
       | sed 's/.*: "\(.*\)".*/\1/' \
@@ -113,7 +105,7 @@ then
       ;;
     --list-all) #print version list including rc and alhpa releases and exit (last 10 versions)
       echo "Available versions:"
-      wget -q -O - https://api.github.com/repos/chain4travel/camino-node/releases \
+      wget -q -O - https://api.github.com/repos/chain4travel/caminogo/releases \
       | grep tag_name \
       | sed 's/.*: "\(.*\)".*/\1/' \
       | head
@@ -176,9 +168,9 @@ cd /tmp/camino-node-install
 version=${version:-latest}
 echo "Looking for $getArch version $version..."
 if [ "$version" = "latest" ]; then
-  fileName="$(curl -s https://api.github.com/repos/chain4travel/camino-node/releases/latest | grep "camino-node-linux-$getArch.*tar\(.gz\)*\"" | cut -d : -f 2,3 | tr -d \" | cut -d , -f 2)"
+  fileName="$(curl -s https://api.github.com/repos/chain4travel/caminogo/releases/latest | grep "caminogo-linux-$getArch.*tar\(.gz\)*\"" | cut -d : -f 2,3 | tr -d \" | cut -d , -f 2)"
 else
-  fileName="https://github.com/chain4travel/camino-node/releases/download/$version/camino-node-linux-$getArch-$version.tar.gz"
+  fileName="https://github.com/chain4travel/caminogo/releases/download/$version/caminogo-linux-$getArch-$version.tar.gz"
 fi
 if [[ `wget -S --spider $fileName  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   echo "Node version found."
@@ -194,8 +186,8 @@ echo "Attempting to download: $fileName"
 wget -nv --show-progress $fileName
 echo "Unpacking node files..."
 mkdir -p $HOME/camino-node
-tar xvf camino-node-linux*.tar.gz -C $HOME/camino-node --strip-components=1;
-rm camino-node-linux-*.tar.gz
+tar xvf caminogo-linux*.tar.gz -C $HOME/camino-node --strip-components=1;
+rm caminogo-linux-*.tar.gz
 echo "Node files unpacked into $HOME/camino-node"
 echo
 if [ "$foundCaminoNode" = "true" ]; then


### PR DESCRIPTION
- added release notes for v1.1.0
  - moved release notes to **caminogo** page
- changed current node version to v1.1.0
- added caminogo installer script
- updated the old script to output a warning message with a link to the new script
- replace camino-node with caminogo in the auto install page (we need another PR to update all node related pages to use caminogo)
