### PR TITLE
Add Camino Messenger Account and Partner configuration to glossary

### DIFF
--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -86,6 +86,9 @@ relaying messages between bots. Currently, Matrix messenger server is used.
 The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
 It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
 
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)
+More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
+
 ## Camino Messenger Protocol
 
 Camino Messenger Protocol (CMP) was developed as the communication protocol for

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -86,7 +86,7 @@ relaying messages between bots. Currently, Matrix messenger server is used.
 The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
 It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
 
-The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners) or - for development purposes on Columbus only - by using a [cli tool](https://github.com/chain4travel/camino-messenger-bot?tab=readme-ov-file#camino-messenger-account-cm-account)
 
 More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -455,11 +455,12 @@ More details can be found in our functional documentation: [Camino Partner Confi
 
 ## Partner plugin
 
-The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate
-seamlessly with distribution and supplier systems.
+The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate with the Partner distribution or inventory system.
 
 This is developed by the suppliers to link their inventory systems with the Camino
 Messenger Bot.
+
+More details can be found in our functional documentation: [Camino Messenger Bot Partner Plugin](https://docs.camino.network/camino-messenger/bot/partner-plugin "Camino Messenger Bot Partner Plugin")
 
 ## PAX
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -68,6 +68,15 @@ Partner building dApps or an integration with Camino Network.
 An efficient travel data exchange system built on Camino Network for instant
 communication between suppliers and distributors.
 
+## Camino Messenger Account
+
+The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
+It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
+
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners) or - for development purposes on Columbus only - by using a [cli tool](https://github.com/chain4travel/camino-messenger-bot?tab=readme-ov-file#camino-messenger-account-cm-account)
+
+More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
+
 ## Camino Messenger Bot
 
 A client-implementation for sending and receiving messages via the Camino Messenger.
@@ -80,15 +89,6 @@ so-called [partner plugins](#partner-plugin).
 
 The backbone of the Camino Messenger infrastructure. Essentially, it's a server
 relaying messages between bots. Currently, Matrix messenger server is used.
-
-## Camino Messenger Account
-
-The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
-It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
-
-The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners) or - for development purposes on Columbus only - by using a [cli tool](https://github.com/chain4travel/camino-messenger-bot?tab=readme-ov-file#camino-messenger-account-cm-account)
-
-More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
 
 ## Camino Messenger Protocol
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -456,7 +456,7 @@ service.
 ## OTA
 
 Online Travel Agency. OTAs are online platforms or websites that allow consumers
-planning and booking various travel-related services and products often offering a
+planning and booking various travel-related services and products, often offering a
 wide range of options and choices from different suppliers.
 
 ## Partner Configuration
@@ -467,12 +467,11 @@ Network. Upon matching between services wanted and offered by two parties, such
 services will be then traded on Camino Messenger.
 
 More details can be found in our functional documentation: [Camino Partner
-Configuration](/partners/partner-config "Camino Partner
-Configuration")
+Configuration](/partners/partner-config)
 
 ## Partner Plugin
 
-The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate
+The Partner Plugin serves as a bridge, enabling the Camino Messenger Bot to integrate
 with the Partner distribution or inventory system.
 
 This is developed by the suppliers to link their inventory systems with the Camino

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -70,12 +70,24 @@ communication between suppliers and distributors.
 
 ## Camino Messenger Account
 
-The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
-It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
+The Camino Messenger Account is a smart contract (actually an ensemble of smart
+contracts), acting as the financial backbone of the [Partner
+Configuration](#partner-configuration), holding the funds designated for trading on
+behalf of the Partner on the Camino Messenger, and paying / receiving payment
+amounts for bookings.
 
-The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners) or - for development purposes on Columbus only - by using a [cli tool](https://github.com/chain4travel/camino-messenger-bot?tab=readme-ov-file#camino-messenger-account-cm-account)
+It also stores all configuration settings such as the services offered and wanted
+(and their versions), the applicable service fees and the accepted currencies. It
+also maintains a list of the wallets of the off-chain bots with which the Partner's
+systems interact with the Messenger.
 
-More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino
+Suite](https://suite.camino.network/partners) or - for development purposes on
+Columbus only - by using a [cli
+tool](https://github.com/chain4travel/camino-messenger-bot?tab=readme-ov-file#camino-messenger-account-cm-account)
+
+More details can be found in our functional documentation: [Camino Partner
+Showroom](/partners/partner-showroom)
 
 ## Camino Messenger Bot
 
@@ -85,7 +97,7 @@ underlying technology stack changes and evolves over time. It offers endpoints t
 communicate with the Camino Messenger network and can actively send requests to
 so-called [partner plugins](#partner-plugin).
 
-## Camino Messenger server
+## Camino Messenger Server
 
 The backbone of the Camino Messenger infrastructure. Essentially, it's a server
 relaying messages between bots. Currently, Matrix messenger server is used.
@@ -96,7 +108,7 @@ Camino Messenger Protocol (CMP) was developed as the communication protocol for
 Camino Messenger. It is used for (de)serializing messages between
 [bots](#camino-messenger-bot) and [partner plugins](#partner-plugin)
 
-More details can be found in our functional documentation: [Camino Messenger Protocol Documentation](https://docs.camino.network/camino-messenger/introduction)
+More details can be found in our functional documentation: [Camino Messenger Protocol Documentation](/camino-messenger/introduction)
 
 ## Camino Network
 
@@ -449,18 +461,25 @@ wide range of options and choices from different suppliers.
 
 ## Partner Configuration
 
-The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.
+The Partner Configuration allows Partners to make themselves known to the Camino
+Network as service providers, or as looking for services from other Partners in the
+Network. Upon matching between services wanted and offered by two parties, such
+services will be then traded on Camino Messenger.
 
-More details can be found in our functional documentation: [Camino Partner Configuration](https://docs.camino.network/partners/partner-config "Camino Partner Configuration")
+More details can be found in our functional documentation: [Camino Partner
+Configuration](/partners/partner-config "Camino Partner
+Configuration")
 
-## Partner plugin
+## Partner Plugin
 
-The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate with the Partner distribution or inventory system.
+The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate
+with the Partner distribution or inventory system.
 
 This is developed by the suppliers to link their inventory systems with the Camino
 Messenger Bot.
 
-More details can be found in our functional documentation: [Camino Messenger Bot Partner Plugin](https://docs.camino.network/camino-messenger/bot/partner-plugin "Camino Messenger Bot Partner Plugin")
+More details can be found in our functional documentation: [Camino Messenger Bot
+Partner Plugin](/camino-messenger/bot/partner-plugin)
 
 ## PAX
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -18,8 +18,8 @@ words, all closely meaning the same thing, and causing confusion.
 | ASB     | [Application Service Bot](#application-service-bot)                         |
 | CM      | [Camino Messenger](#camino-messenger)                                       |
 | CMA     | [Camino Messenger Account](#camino-messenger-account)                       |
-| CMP     | [Camino Messenger Protocol](#camino-messenger-protocol)                     |
 | CMB     | [Camino Messenger Bot](#camino-messenger-bot)                               |
+| CMP     | [Camino Messenger Protocol](#camino-messenger-protocol)                     |
 | DAC     | [Decentralized Autonomous Consortium](#decentralized-autonomous-consortium) |
 | EOA     | [Externally Owned Account](#externally-owned-account)                       |
 | EVM     | [Ethereum Virtual Machine](#ethereum-virtual-machine)                       |
@@ -86,7 +86,8 @@ relaying messages between bots. Currently, Matrix messenger server is used.
 The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
 It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
 
-The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)  
+
 More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
 
 ## Camino Messenger Protocol
@@ -448,8 +449,10 @@ More details can be found in our functional documentation: [Camino Messenger Pro
 
 ## Partner Configuration
 
-The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.
+The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.  
+
 More details can be found in our functional documentation: [Camino Partner Configuration](https://docs.camino.network/partners/partner-config "Camino Partner Configuration")
+
 ## Partner plugin
 
 The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -14,9 +14,10 @@ words, all closely meaning the same thing, and causing confusion.
 ## Acronyms
 
 | Short   | Long                                                                        |
-| ------- | --------------------------------------------------------------------------- |
+|---------| --------------------------------------------------------------------------- |
 | ASB     | [Application Service Bot](#application-service-bot)                         |
 | CM      | [Camino Messenger](#camino-messenger)                                       |
+| CMA     | [Camino Messenger Account](#camino-messenger-account)                       |
 | CMP     | [Camino Messenger Protocol](#camino-messenger-protocol)                     |
 | CMB     | [Camino Messenger Bot](#camino-messenger-bot)                               |
 | DAC     | [Decentralized Autonomous Consortium](#decentralized-autonomous-consortium) |
@@ -79,6 +80,11 @@ so-called [partner plugins](#partner-plugin).
 
 The backbone of the Camino Messenger infrastructure. Essentially, it's a server
 relaying messages between bots. Currently, Matrix messenger server is used.
+
+## Camino Messenger Account
+
+The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
+It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
 
 ## Camino Messenger Protocol
 
@@ -434,6 +440,10 @@ service.
 Online Travel Agency. OTAs are online platforms or websites that allow consumers to
 research plan and book various travel-related services and products often offering a
 wide range of options and choices from different suppliers.
+
+## Partner Configuration
+
+The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.
 
 ## Partner plugin
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -86,7 +86,7 @@ relaying messages between bots. Currently, Matrix messenger server is used.
 The Camino Messenger Account is a smart contract (actually an ensemble of smart contracts), acting as the financial backbone of the [Partner Configuration](#partner-configuration), holding the funds designated for trading on behalf of the Partner on the Camino Messenger, and paying / receiving payment amounts for bookings.  
 It also stores all configuration settings such as the services offered and wanted (and their versions), the applicable service fees and the accepted currencies. It also maintains a list of the wallets of the off-chain bots with which the Partner's systems interact with the Messenger.
 
-The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)  
+The Camino Messenger Account can be created from the Partner Showroom of the [Camino Suite](https://suite.camino.network/partners)
 
 More details can be found in our functional documentation: [Camino Partner Showroom](https://docs.camino.network/partners/partner-showroom "Camino Partner Showroom")
 
@@ -449,7 +449,7 @@ More details can be found in our functional documentation: [Camino Messenger Pro
 
 ## Partner Configuration
 
-The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.  
+The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.
 
 More details can be found in our functional documentation: [Camino Partner Configuration](https://docs.camino.network/partners/partner-config "Camino Partner Configuration")
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -14,7 +14,7 @@ words, all closely meaning the same thing, and causing confusion.
 ## Acronyms
 
 | Short   | Long                                                                        |
-|---------| --------------------------------------------------------------------------- |
+| ------- | --------------------------------------------------------------------------- |
 | ASB     | [Application Service Bot](#application-service-bot)                         |
 | CM      | [Camino Messenger](#camino-messenger)                                       |
 | CMA     | [Camino Messenger Account](#camino-messenger-account)                       |

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -443,7 +443,7 @@ service.
 
 ## OTA
 
-Online Travel Agency. OTAs are online platforms or websites that allow consumers to
+Online Travel Agency. OTAs are online platforms or websites that allow consumers
 planning and booking various travel-related services and products often offering a
 wide range of options and choices from different suppliers.
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -96,6 +96,8 @@ Camino Messenger Protocol (CMP) was developed as the communication protocol for
 Camino Messenger. It is used for (de)serializing messages between
 [bots](#camino-messenger-bot) and [partner plugins](#partner-plugin)
 
+More details can be found in our functional documentation: [Camino Messenger Protocol Documentation](https://docs.camino.network/camino-messenger/introduction)
+
 ## Camino Network
 
 Comprehensive ecosystem with a vast amount of industry partners designed
@@ -444,8 +446,6 @@ service.
 Online Travel Agency. OTAs are online platforms or websites that allow consumers to
 planning and booking various travel-related services and products often offering a
 wide range of options and choices from different suppliers.
-
-More details can be found in our functional documentation: [Camino Messenger Protocol Documentation](https://docs.camino.network/camino-messenger/introduction)
 
 ## Partner Configuration
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -438,8 +438,10 @@ service.
 ## OTA
 
 Online Travel Agency. OTAs are online platforms or websites that allow consumers to
-research plan and book various travel-related services and products often offering a
+planning and booking various travel-related services and products often offering a
 wide range of options and choices from different suppliers.
+
+More details can be found in our functional documentation: [Camino Messenger Protocol Documentation](https://docs.camino.network/camino-messenger/introduction)
 
 ## Partner Configuration
 

--- a/docs/faq/glossary.md
+++ b/docs/faq/glossary.md
@@ -444,7 +444,7 @@ wide range of options and choices from different suppliers.
 ## Partner Configuration
 
 The Partner Configuration allows Partners to make themselves known to the Camino Network as service providers, or as looking for services from other Partners in the Network. Upon matching between services wanted and offered by two parties, such services will be then traded on Camino Messenger.
-
+More details can be found in our functional documentation: [Camino Partner Configuration](https://docs.camino.network/partners/partner-config "Camino Partner Configuration")
 ## Partner plugin
 
 The Partner Plugin serves as a bridge enabling the Camino Messenger Bot to integrate


### PR DESCRIPTION
Small PR suggested by @nkoljanin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added definitions for "Camino Messenger Account" and "Partner Configuration" to the glossary.
	- Updated acronym list to include "CMA" for "Camino Messenger Account" while retaining "CMP" for "Camino Messenger Protocol."

- **Documentation**
	- Enhanced glossary structure for improved clarity and context regarding terms related to the Camino ecosystem.
	- Capitalized "Camino Messenger Server" for consistency and made minor wording adjustments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->