### PR TITLE
Remove presale consortium msg

### DIFF
--- a/docs/validator-guides/add-validator-with-curl.md
+++ b/docs/validator-guides/add-validator-with-curl.md
@@ -54,7 +54,7 @@ Further below, you will find instructions about how to get these information by 
 - **100,000 non-bonded CAMs** in your P-Chain wallet. And a few CAMs for paying for transaction fees.<br/>
   You can check this on the online [wallet](https://suite.camino.network/wallet) to ensure that you have at least 100,000 non-bonded tokens on the P-Chain.
 - **Consortium Member**: Your wallet address must be a consortium member.<br/>
-  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification. If you participated in the pre-sale, you are already a Consortium Member.
+  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification.
 - **KYC/KYB Verified**: You must be Know-Your-Customer (KYC) or Know-Your-Business (KYB) verified.
 
 :::note PRE-SALE PARTICIPANTS

--- a/docs/validator-guides/add-validator-with-msig.md
+++ b/docs/validator-guides/add-validator-with-msig.md
@@ -72,7 +72,7 @@ Below is a list of these requirements for the mainnet (`camino`) and testnet (`c
   Keep it safe and secure!
 - **100,000 non-bonded CAMs** in your P-Chain wallet. And a few CAMs for paying for transaction fees.
 - **Consortium Member**: Your wallet address must be a consortium member.<br/>
-  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification. If you participated in the pre-sale, provided a wallet address, and are a travel-related company, you are already a Consortium Member.
+  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification.
 - **KYC/KYB Verified**: You must be Know-Your-Customer (KYC) or Know-Your-Business (KYB) verified.
 
 ### Checking Requirements Using Camino Wallet

--- a/docs/validator-guides/add-validator-with-wallet.md
+++ b/docs/validator-guides/add-validator-with-wallet.md
@@ -53,7 +53,7 @@ Below is a list of these requirements for the mainnet (`camino`) and testnet (`c
   Keep it safe and secure!
 - **100,000 non-bonded CAMs** in your P-Chain wallet. And a few CAMs for paying for transaction fees.<br/>
 - **Consortium Member**: Your wallet address must be a consortium member.<br/>
-  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification. If you participated in the pre-sale, you are already a Consortium Member.
+  If you are unsure about this, please reach out to us on [Discord](https://discord.gg/camino) for clarification.
 - **KYC/KYB Verified**: You must be Know-Your-Customer (KYC) or Know-Your-Business (KYB) verified.
 
 ### Checking Requirements Using Camino Wallet

--- a/docs/validator-guides/renew-validator.md
+++ b/docs/validator-guides/renew-validator.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 33
+sidebar_position: 35
 title: Renew Validation Period
 description: A guide on how to renew the validation period after expiration.
 ---


### PR DESCRIPTION
- Remove presale consortium membership message. This message is redundant and not exactly correct.
- Adjust ordering of the side panel to fix renew period page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated validator guide for adding a validator node with cURL to indicate method deprecation
	- Simplified consortium membership requirements across multiple validator guide documents
	- Adjusted sidebar position for renew validator documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->