### PR TITLE
Add release notes for v1.2.0-rc6

### DIFF
--- a/docs/release-notes/caminogo.md
+++ b/docs/release-notes/caminogo.md
@@ -12,11 +12,30 @@ Development has been transitioned from the `camino-node` repository to the
 
 :::
 
+## v1.2.0-rc6
+
+:::warning ONLY ON COLUMBUS TESTNET
+
+This is a pre-release for Columbus testnet. It **SHOULD NOT** be used for **Camino mainnet**.
+
+:::
+
+<p><span class="alert alert--info pill">Cairo Phase</span></p>
+<p><span class="alert alert--warning pill">Pre-Release</span></p>
+<p><span class="alert alert--secondary pill">Current Testnet (Columbus) Version</span></p>
+
+[View on Github](https://github.com/chain4travel/caminogo/releases/tag/v1.2.0-rc6)
+
+- Implementation of Cairo phase
+- Cairo Timestamp for Columbus is 2025-07-16 at 11:00 UTC
+- Fix DAC general proposals
+- Introduce new system transaction `UnlockExpiredDepositsTx` that will handle unlock of expired deposits after Cairo.
+- Fix `UnlockDepositTx` active deposits partial unlocking.
+
 ## v1.1.0
 
 <p><span class="alert alert--info pill">Berlin Phase</span></p>
 <p><span class="alert alert--secondary pill">Current Mainnet (Camino) Version</span></p>
-<p><span class="alert alert--secondary pill">Current Testnet (Columbus) Version</span></p>
 
 [View on GitHub](https://github.com/chain4travel/caminogo/releases/tag/v1.1.0)
 


### PR DESCRIPTION
This PR adds release notes for caminogo v1.2.0-rc6 (Cairo).

Playground link: https://playground.docs.camino.network/release-notes/caminogo/index.html